### PR TITLE
squash! make varlink optional for podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,7 @@ SYSTEMDDIR ?= ${PREFIX}/lib/systemd/system
 BUILDTAGS ?= seccomp $(shell hack/btrfs_tag.sh) $(shell hack/libdm_tag.sh) $(shell hack/btrfs_installed_tag.sh) $(shell hack/ostree_tag.sh) $(shell hack/selinux_tag.sh) varlink
 
 ifneq (,$(findstring varlink,$(BUILDTAGS)))
-	WANTVARLINK=true
-else
-	WANTVARLINK=false
+	PODMAN_VARLINK_DEPENDENCIES = cmd/podman/varlink/ioprojectatomicpodman.go
 endif
 
 PYTHON ?= /usr/bin/python3
@@ -99,7 +97,7 @@ test/copyimg/copyimg: .gopathok $(wildcard test/copyimg/*.go)
 test/checkseccomp/checkseccomp: .gopathok $(wildcard test/checkseccomp/*.go)
 	$(GO) build -ldflags '$(LDFLAGS)' -tags "$(BUILDTAGS) containers_image_ostree_stub" -o $@ $(PROJECT)/test/checkseccomp
 
-podman: .gopathok API.md cmd/podman/varlink/ioprojectatomicpodman.go
+podman: .gopathok $(PODMAN_VARLINK_DEPENDENCIES)
 	$(GO) build -i -ldflags '$(LDFLAGS_PODMAN)' -tags "$(BUILDTAGS)" -o bin/$@ $(PROJECT)/cmd/podman
 
 python-podman:
@@ -278,14 +276,10 @@ install.libseccomp.sudo:
 
 
 cmd/podman/varlink/ioprojectatomicpodman.go: cmd/podman/varlink/io.projectatomic.podman.varlink
-ifeq ($(WANTVARLINK), true)
 	$(GO) generate ./cmd/podman/varlink/...
-endif
 
 API.md: cmd/podman/varlink/io.projectatomic.podman.varlink
-ifeq ($(WANTVARLINK), true)
 	$(GO) generate ./docs/...
-endif
 
 validate: gofmt .gitvalidation
 


### PR DESCRIPTION
The `API.md` and `cmd/podman/varlink/ioprojectatomicpodman.go` targets will continue to work regardless of the presence (or not) of `varlink` is in `BUILDTAGS`.  However, `cmd/podman/varlink/ioprojectatomicpodman.go` is now only required by the `podman` target when `BUILDTAGS` contains `varlink`.

`API.md` had also been an podman dependency since 5b2627dd (projectatomic/libpod#776) when I expanded `varlink_api_generate`.  It had been an indirect podman dependency (via `varlink_api_generate`) since 25263558 (projectatomic/libpod#734).  But the `podman` executable obviously doesn't depend on the Markdown file, so I'm removing that dependency here.