### PR TITLE
Do not parse --network when --pod is set

### DIFF
--- a/cmd/podman/common/netflags.go
+++ b/cmd/podman/common/netflags.go
@@ -193,27 +193,25 @@ func NetFlagsToNetOptions(cmd *cobra.Command) (*entities.NetOptions, error) {
 		return nil, err
 	}
 
-	if cmd.Flags().Changed("network") {
-		network, err := cmd.Flags().GetString("network")
-		if err != nil {
-			return nil, err
-		}
-
-		parts := strings.SplitN(network, ":", 2)
-
-		ns, cniNets, err := specgen.ParseNetworkNamespace(network, containerConfig.Containers.RootlessNetworking == "cni")
-		if err != nil {
-			return nil, err
-		}
-
-		if len(parts) > 1 {
-			opts.NetworkOptions = make(map[string][]string)
-			opts.NetworkOptions[parts[0]] = strings.Split(parts[1], ",")
-			cniNets = nil
-		}
-		opts.Network = ns
-		opts.CNINetworks = cniNets
+	network, err := cmd.Flags().GetString("network")
+	if err != nil {
+		return nil, err
 	}
+
+	parts := strings.SplitN(network, ":", 2)
+
+	ns, cniNets, err := specgen.ParseNetworkNamespace(network, containerConfig.Containers.RootlessNetworking == "cni")
+	if err != nil {
+		return nil, err
+	}
+
+	if len(parts) > 1 {
+		opts.NetworkOptions = make(map[string][]string)
+		opts.NetworkOptions[parts[0]] = strings.Split(parts[1], ",")
+		cniNets = nil
+	}
+	opts.Network = ns
+	opts.CNINetworks = cniNets
 
 	aliases, err := cmd.Flags().GetStringSlice("network-alias")
 	if err != nil {

--- a/cmd/podman/containers/create.go
+++ b/cmd/podman/containers/create.go
@@ -89,7 +89,7 @@ func create(cmd *cobra.Command, args []string) error {
 	var (
 		err error
 	)
-	cliVals.Net, err = common.NetFlagsToNetOptions(cmd)
+	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "")
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/containers/run.go
+++ b/cmd/podman/containers/run.go
@@ -108,7 +108,7 @@ func init() {
 
 func run(cmd *cobra.Command, args []string) error {
 	var err error
-	cliVals.Net, err = common.NetFlagsToNetOptions(cmd)
+	cliVals.Net, err = common.NetFlagsToNetOptions(cmd, cliVals.Pod == "")
 	if err != nil {
 		return err
 	}

--- a/cmd/podman/pods/create.go
+++ b/cmd/podman/pods/create.go
@@ -167,22 +167,9 @@ func create(cmd *cobra.Command, args []string) error {
 		defer errorhandling.SyncQuiet(podIDFD)
 	}
 
-	createOptions.Net, err = common.NetFlagsToNetOptions(cmd)
+	createOptions.Net, err = common.NetFlagsToNetOptions(cmd, createOptions.Infra)
 	if err != nil {
 		return err
-	}
-
-	net, err := cmd.Flags().GetString("network")
-	if err != nil {
-		return err
-	}
-
-	// If there is no infra container and the network flag was not set or set to "" or "default"
-	// set the the network namespace back to the default value. This is needed because
-	// NetFlagsToNetOptions sets the nsmode to either slirp or bridge in such case and specgen
-	// complains when a nsmode other than default is used with no infra container.
-	if !createOptions.Infra && (!cmd.Flag("network").Changed || net == "" || net == "default") {
-		createOptions.Net.Network = specgen.Namespace{NSMode: specgen.Default}
 	}
 
 	if len(createOptions.Net.PublishPorts) > 0 {

--- a/libpod/networking_linux.go
+++ b/libpod/networking_linux.go
@@ -273,7 +273,6 @@ func (r *Runtime) GetRootlessCNINetNs(new bool) (*RootlessCNI, error) {
 				if err != nil {
 					return nil, errors.Wrap(err, "error creating rootless cni network namespace")
 				}
-
 				// setup slirp4netns here
 				path := r.config.Engine.NetworkCmdPath
 				if path == "" {
@@ -437,9 +436,32 @@ func (r *Runtime) GetRootlessCNINetNs(new bool) (*RootlessCNI, error) {
 	return rootlessCNINS, nil
 }
 
+// setPrimaryMachineIP is used for podman-machine and it sets
+// and environment variable with the IP address of the podman-machine
+// host.
+func setPrimaryMachineIP() error {
+	// no connection is actually made here
+	conn, err := net.Dial("udp", "8.8.8.8:80")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := conn.Close(); err != nil {
+			logrus.Error(err)
+		}
+	}()
+	addr := conn.LocalAddr().(*net.UDPAddr)
+	return os.Setenv("PODMAN_MACHINE_HOST", addr.IP.String())
+}
+
 // setUpOCICNIPod will set up the cni networks, on error it will also tear down the cni
 // networks. If rootless it will join/create the rootless cni namespace.
 func (r *Runtime) setUpOCICNIPod(podNetwork ocicni.PodNetwork) ([]ocicni.NetResult, error) {
+	if r.config.MachineEnabled() {
+		if err := setPrimaryMachineIP(); err != nil {
+			return nil, err
+		}
+	}
 	rootlessCNINS, err := r.GetRootlessCNINetNs(true)
 	if err != nil {
 		return nil, err

--- a/pkg/machine/config.go
+++ b/pkg/machine/config.go
@@ -32,6 +32,7 @@ var (
 	ErrVMAlreadyExists                           = errors.New("VM already exists")
 	ErrVMAlreadyRunning                          = errors.New("VM already running")
 	ErrMultipleActiveVM                          = errors.New("only one VM can be active at a time")
+	ForwarderBinaryName                          = "gvproxy"
 )
 
 type Download struct {

--- a/pkg/machine/ignition.go
+++ b/pkg/machine/ignition.go
@@ -118,6 +118,7 @@ func getDirs(usrName string) []Directory {
 	// in one swoop, then the leading dirs are creates as root.
 	newDirs := []string{
 		"/home/" + usrName + "/.config",
+		"/home/" + usrName + "/.config/containers",
 		"/home/" + usrName + "/.config/systemd",
 		"/home/" + usrName + "/.config/systemd/user",
 		"/home/" + usrName + "/.config/systemd/user/default.target.wants",
@@ -159,6 +160,22 @@ func getFiles(usrName string) []File {
 		},
 	})
 
+	// Set containers.conf up for core user to use cni networks
+	// by default
+	files = append(files, File{
+		Node: Node{
+			Group: getNodeGrp(usrName),
+			Path:  "/home/" + usrName + "/.config/containers/containers.conf",
+			User:  getNodeUsr(usrName),
+		},
+		FileEmbedded1: FileEmbedded1{
+			Append: nil,
+			Contents: Resource{
+				Source: strToPtr("data:,%5Bcontainers%5D%0D%0Anetns%3D%22bridge%22%0D%0Arootless_networking%3D%22cni%22"),
+			},
+			Mode: intToPtr(484),
+		},
+	})
 	// Add a file into linger
 	files = append(files, File{
 		Node: Node{

--- a/pkg/machine/qemu/options_darwin.go
+++ b/pkg/machine/qemu/options_darwin.go
@@ -6,7 +6,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func getSocketDir() (string, error) {
+func getRuntimeDir() (string, error) {
 	tmpDir, ok := os.LookupEnv("TMPDIR")
 	if !ok {
 		return "", errors.New("unable to resolve TMPDIR")

--- a/pkg/machine/qemu/options_darwin_amd64.go
+++ b/pkg/machine/qemu/options_darwin_amd64.go
@@ -5,7 +5,7 @@ var (
 )
 
 func (v *MachineVM) addArchOptions() []string {
-	opts := []string{"-cpu", "host"}
+	opts := []string{"-machine", "q35,accel=hvf:tcg"}
 	return opts
 }
 

--- a/pkg/machine/qemu/options_linux.go
+++ b/pkg/machine/qemu/options_linux.go
@@ -1,7 +1,13 @@
 package qemu
 
-import "github.com/containers/podman/v3/pkg/util"
+import (
+	"github.com/containers/podman/v3/pkg/rootless"
+	"github.com/containers/podman/v3/pkg/util"
+)
 
-func getSocketDir() (string, error) {
+func getRuntimeDir() (string, error) {
+	if !rootless.IsRootless() {
+		return "/run", nil
+	}
 	return util.GetRuntimeDir()
 }


### PR DESCRIPTION
Always parsing the --network flag does not work since it overwrites the
pod netns when --pod is given to `podman create/run` command. Parse
the --network value only when it is explicity given on the command line
or when --pod is not used. With `podman pod create` do not parse it when
no infra container is created.

This still does not work when a pod without shared netns is used. In
this case we will use the default netns instead of the one from the
config file. Making this work requires reworking the parsing logic and
moving it into specgen.

Signed-off-by: Paul Holzinger <pholzing@redhat.com>